### PR TITLE
起動時の設定読み込みでメモリが無駄に消費される問題を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2877,7 +2877,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
       "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
-      "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -2886,8 +2885,7 @@
         "indent-string": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-          "dev": true
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
         }
       }
     },
@@ -3782,8 +3780,7 @@
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cliui": {
       "version": "5.0.0",
@@ -8899,7 +8896,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "chart.js": "^2.9.3",
+    "p-map": "^4.0.0",
     "simple-statistics": "^7.1.0",
     "tiny-segmenter": "^0.2.0",
     "vue": "^2.6.11",

--- a/src/lib/StatisticsUtil.ts
+++ b/src/lib/StatisticsUtil.ts
@@ -2,6 +2,8 @@ import StatisticsLog from "@/models/StatisticsLog"
 import msgUtil from "./MessageUtil"
 import ReLearnLog from "@/models/ReLearnLog"
 import pMap from "p-map"
+import { StorageObj } from "./StorageUtil"
+import StorageUtil from "./StorageUtil"
 
 export default class StatisticsUtil {
   static readonly STATISTICS_LOG_PREFIX = "__stat_"
@@ -91,7 +93,7 @@ export default class StatisticsUtil {
   /**
    * 古い日付の統計データを削除する
    */
-  public static async removeOldStatistics() {
+  public static async removeOldStatistics(setting: StorageObj) {
     const nowDate = new Date()
     const deleteDate = this.DELETE_STATISTICS_PAST_DAY
 
@@ -103,26 +105,34 @@ export default class StatisticsUtil {
           await browser.storage.sync.remove(keyName)
         }
       }
-    })
+    }, setting)
   }
 
   /**
    * 日付毎の統計情報をすべて削除する
    */
   public static async removeAllStatistics() {
+    const setting = await StorageUtil.getStorageAll()
     this.listStatistics(async (keyName) => {
       await browser.storage.sync.remove(keyName)
-    })
+    }, setting)
+  }
+
+  public static async getListStatisticsFromStorage(): Promise<StatisticsLog[]> {
+    const setting = await StorageUtil.getStorageAll()
+    return await this.getListStatistics(setting)
   }
 
   /**
    * 日付昇順にソートした統計オブジェクトの配列を返す
    */
-  public static async getListStatistics(): Promise<StatisticsLog[]> {
+  public static async getListStatistics(
+    setting: StorageObj
+  ): Promise<StatisticsLog[]> {
     const ret: StatisticsLog[] = []
     await this.listStatistics(async (keyname, log) => {
       ret.push(log)
-    })
+    }, setting)
 
     const retSorted: StatisticsLog[] = ret.sort((a, b): number => {
       const aDate = typeof a.date === "undefined" ? new Date(0) : a.date
@@ -147,13 +157,9 @@ export default class StatisticsUtil {
    * @param callback 統計オブジェクト毎に行いたい処理を指定
    */
   public static async listStatistics(
-    callback: (keyName: string, log: StatisticsLog) => Promise<void>
+    callback: (keyName: string, log: StatisticsLog) => Promise<void>,
+    setting: StorageObj
   ) {
-    // まずsettingが名前インデックス付きであることを定義
-    const setting = (await browser.storage.sync.get(null)) as {
-      [keyname: string]: object
-    }
-
     const ret: StatisticsLog[] = []
     for (const item in setting) {
       // キーの先頭文字でログであることを判断。他の設定で同様のキーを作ると誤動作する。
@@ -208,7 +214,7 @@ export default class StatisticsUtil {
   /**
    * 古い日付の再学習ログデータを削除する
    */
-  public static async removeOldReLearnLog() {
+  public static async removeOldReLearnLog(setting: StorageObj) {
     const nowDate = new Date()
     const deleteDate = this.DELETE_RE_LEARN_LOG_PAST_DAY
 
@@ -221,7 +227,7 @@ export default class StatisticsUtil {
           keys.push(keyName)
         }
       }
-    })
+    }, setting)
     // 負荷を抑えるために非同期処理の並行処理数を制限する
     await pMap(
       keys,
@@ -236,9 +242,10 @@ export default class StatisticsUtil {
    * 再学習ログデータをすべて削除する
    */
   public static async removeAllReLearnLog() {
+    const setting = await StorageUtil.getStorageAll()
     this.listReLearnLog(async (keyName) => {
       browser.storage.sync.remove(keyName)
-    })
+    }, setting)
   }
 
   /**
@@ -246,13 +253,9 @@ export default class StatisticsUtil {
    * @param callback 再学習ログ毎に行いたい処理を指定
    */
   public static async listReLearnLog(
-    callback: (keyName: string, log: ReLearnLog) => Promise<void>
+    callback: (keyName: string, log: ReLearnLog) => Promise<void>,
+    setting: StorageObj
   ) {
-    // まずsettingが名前インデックス付きであることを定義
-    const setting = (await browser.storage.sync.get(null)) as {
-      [keyname: string]: object
-    }
-
     const ret: ReLearnLog[] = []
     for (const item in setting) {
       // キーの先頭文字でログであることを判断。他の設定で同様のキーを作ると誤動作する。

--- a/src/lib/StatisticsUtil.ts
+++ b/src/lib/StatisticsUtil.ts
@@ -1,13 +1,16 @@
 import StatisticsLog from "@/models/StatisticsLog"
 import msgUtil from "./MessageUtil"
 import ReLearnLog from "@/models/ReLearnLog"
+import pMap from "p-map"
 
 export default class StatisticsUtil {
   static readonly STATISTICS_LOG_PREFIX = "__stat_"
   static readonly RE_LEARN_LOG_PREFIX = "__relog_"
   static readonly TOTAL_STATISTICS_KEY: string = "statistics"
   static readonly DELETE_STATISTICS_PAST_DAY: number = 30
-  static readonly DELETE_RE_LEARN_LOG_PAST_DAY: number = 30
+  static readonly DELETE_RE_LEARN_LOG_PAST_DAY: number = 0
+  /** 再学習ログの並行処理数 */
+  static readonly DELETE_RE_LEARN_LOG_CONCURRENCY: number = 10
 
   public static async loadTotalStatistics(): Promise<StatisticsLog> {
     const result = (await browser.storage.sync.get(
@@ -209,15 +212,24 @@ export default class StatisticsUtil {
     const nowDate = new Date()
     const deleteDate = this.DELETE_RE_LEARN_LOG_PAST_DAY
 
-    this.listReLearnLog(async (keyName, log) => {
+    const keys: string[] = []
+    await this.listReLearnLog(async (keyName, log) => {
       if (typeof log.date != "undefined") {
         const dateDiff =
           (nowDate.getTime() - log.date.getTime()) / (1000 * 60 * 60 * 24)
         if (dateDiff > deleteDate) {
-          browser.storage.sync.remove(keyName)
+          keys.push(keyName)
         }
       }
     })
+    // 負荷を抑えるために非同期処理の並行処理数を制限する
+    await pMap(
+      keys,
+      async (keyName) => {
+        browser.storage.sync.remove(keyName)
+      },
+      { concurrency: this.DELETE_RE_LEARN_LOG_CONCURRENCY }
+    )
   }
 
   /**

--- a/src/lib/StorageUtil.ts
+++ b/src/lib/StorageUtil.ts
@@ -1,0 +1,16 @@
+export default class StatisticsUtil {
+  /**
+   * ストレージから全設定データを取得する
+   */
+  public static async getStorageAll(): Promise<StorageObj> {
+    // まずsettingが名前インデックス付きであることを定義
+    return (await browser.storage.sync.get(null)) as StorageObj
+  }
+}
+
+/**
+ * ストレージ(設定)用 型定義
+ */
+export interface StorageObj {
+  [keyname: string]: object
+}

--- a/src/statistics/router/pages/Index.vue
+++ b/src/statistics/router/pages/Index.vue
@@ -190,7 +190,7 @@ export default class App extends Vue {
   private async loadStatistics() {
     let data: number[] = [];
     let dateLabel: string[] = [];
-    const items: StatisticsLog[] = await StatisticsUtil.getListStatistics();
+    const items: StatisticsLog[] = await StatisticsUtil.getListStatisticsFromStorage();
     for (const item of items) {
       data.push(
         100 - Math.round((item.wrongCount / item.totalCount) * 100 * 10) / 10


### PR DESCRIPTION
過去の古いデータを削除するために設定を保存しているストレージ全体を読み込む処理を入れているが、並列で全データを読み込む処理になっていたので、並列読み込みをやめて、読み込みは一回だけにするようにした。

また、取得したログ情報の削除処理を無制限で並列処理していたのを10件毎の並列処理に制限。
