### PR TITLE
Compatibility with Thunderbird 128

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,7 +12,7 @@
   "applications": {
     "gecko": {
       "id": "autobacket@a-tak.com",
-      "strict_min_version": "128.0"
+      "strict_min_version": "122.0"
     }
   },
   "default_locale": "en",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,11 +12,19 @@
   "applications": {
     "gecko": {
       "id": "autobacket@a-tak.com",
-      "strict_min_version": "78.0"
+      "strict_min_version": "128.0"
     }
   },
   "default_locale": "en",
-  "permissions": ["messagesRead", "menus", "storage", "accountsRead", "notifications", "unlimitedStorage"],
+  "permissions": [
+    "messagesRead",
+    "messagesUpdate",
+    "menus",
+    "storage",
+    "accountsRead",
+    "notifications",
+    "unlimitedStorage"
+  ],
   "browser_action": {
     "default_icon": "icons/icon_48.png",
     "default_title": "AutoBucket",


### PR DESCRIPTION
Thunderbird 128 introduced a rare backward incompatibility in its WebExtension API: The method `messages.update()` is now protected by the `messagesUpdate` permission.